### PR TITLE
marked string containing an umlaut as Unicode

### DIFF
--- a/pipdated/helpers.py
+++ b/pipdated/helpers.py
@@ -30,7 +30,7 @@ if not os.path.exists(_config_dir):
     os.makedirs(_config_dir)
 _config_file = os.path.join(_config_dir, 'config.ini')
 
-_log_dir = appdirs.user_log_dir('pipdated', 'Nico Schlömer')
+_log_dir = appdirs.user_log_dir('pipdated', u'Nico Schlömer')
 if not os.path.exists(_log_dir):
     os.makedirs(_log_dir)
 _log_file = os.path.join(_log_dir, 'times.log')


### PR DESCRIPTION
I confess to finding working with Unicode a bit confusing, so this may not be the correct fix, but to successfully 'pip install' pygmsh which depends on this package, I had to prepend the u to the string to avoid the UnicodeDecodeError.