### PR TITLE
Scope importlib-metadata to python<3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 # importlib_metadata can be removed when we support Python 3.8+ only
 install_requires =
     appdirs
-    importlib_metadata
+    importlib_metadata; python_version < "3.8"
     requests
     # https://github.com/nschloe/pipdate/pull/39
     setuptools


### PR DESCRIPTION
Was fixing python packages for nixpkgs. Noticed importlib_metadata was missing a python version specifier.