### PR TITLE
remove dependency to pkg resources that is deprecated

### DIFF
--- a/src/pipdate/main.py
+++ b/src/pipdate/main.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 
 import appdirs
-import pkg_resources
+from importlib.metadata import distribution
 from packaging import version
 from rich.console import Console
 from rich.panel import Panel
@@ -104,7 +104,7 @@ def check(name, installed_version):
 
 def _is_pip_installed(name):
     try:
-        installer = pkg_resources.get_distribution(name).get_metadata("INSTALLER")
+        installer = distribution(name).read_text("INSTALLER")
     except FileNotFoundError:
         return False
     return installer.strip() == "pip"


### PR DESCRIPTION
Hello @nschloe , I opened this PR to remove a warning about the deprecation of pkg_resources:

```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

https://setuptools.pypa.io/en/latest/pkg_resources.html